### PR TITLE
feat: count the number of files in every directory when compressing file

### DIFF
--- a/test/components/archiver/archiver.test.js
+++ b/test/components/archiver/archiver.test.js
@@ -29,7 +29,17 @@ describe('Archiver component tests', () => {
   test('should compress a file providing its name', async () => {
     const filename = '2020-09-10';
     const result = await archiver.compressFile('2020-09-10');
-    expect(result).toBe(true);
+    const expectResult = [
+      { '/gnuplot/specs/fakes': 1 },
+      { '/gnuplot/specs/overdense': 1 },
+      { '/gnuplot/specs': 1 },
+      { '/gnuplot/specs/underdense': 1 },
+      { '/screenshots/fakes': 1 },
+      { '/screenshots/overdense': 1 },
+      { '/screenshots/underdense': 1 },
+      { '/stats': 1 },
+    ];
+    expect(result).toEqual(expectResult);
     fs.unlinkSync(path.join(__dirname, `../../fixtures/echoes/${filename}.zip`));
   });
 });


### PR DESCRIPTION
### Main Changes

- Add statistics when compressing file. Statistics are composed by the name of every directory in the daily directory with the number of files for each one.

### Other Changes

- Update `archiver` tests according to changes

### Context

#3 

### Changelog

- 73df5a2 feat: count the number of files in every directory when compressing file by @neodmy
