### PR TITLE
refactor: change date_sent property to just date

### DIFF
--- a/components/store/daily.js
+++ b/components/store/daily.js
@@ -19,7 +19,7 @@ module.exports = () => {
     const insertOne = collection => async payload => {
       const dataToInsert = JSON.stringify(payload);
       logger.info(`${collection.namespace} | Inserting new document: ${dataToInsert}`);
-      const { ops, insertedCount } = await collection.insertOne({ ...payload, retries: 0, date_sent: new Date() });
+      const { ops, insertedCount } = await collection.insertOne({ ...payload, retries: 0, date: new Date() });
       if (!insertedCount) throw new Error(`${collection.namespace} | Could not save data: ${dataToInsert}`);
       return ops[0];
     };

--- a/test/components/store/store.test.js
+++ b/test/components/store/store.test.js
@@ -26,7 +26,7 @@ describe('Store component tests', () => {
       const expectedResult = {
         filename,
         statistics,
-        date_sent: expect.any(Date),
+        date: expect.any(Date),
         retries: 0,
       };
 
@@ -48,7 +48,7 @@ describe('Store component tests', () => {
       const expectedResult = {
         filename,
         statistics,
-        date_sent: expect.any(Date),
+        date: expect.any(Date),
         retries: 0,
       };
 
@@ -94,7 +94,7 @@ describe('Store component tests', () => {
       const expectedResult = {
         filename,
         statistics,
-        date_sent: expect.any(Date),
+        date: expect.any(Date),
         retries: 1,
       };
 
@@ -132,7 +132,7 @@ describe('Store component tests', () => {
       const expectedResult = {
         filename,
         statistics,
-        date_sent: expect.any(Date),
+        date: expect.any(Date),
       };
 
       const { _id: savedId } = await store.daily.insertOneSuccess({ filename, statistics });
@@ -152,7 +152,7 @@ describe('Store component tests', () => {
       const expectedResult = {
         filename,
         statistics,
-        date_sent: expect.any(Date),
+        date: expect.any(Date),
       };
 
       const { _id: savedId } = await store.daily.insertOneFail({ filename, statistics });
@@ -176,11 +176,11 @@ describe('Store component tests', () => {
         {
           filename: filename1,
           statistics,
-          date_sent: expect.any(Date),
+          date: expect.any(Date),
         }, {
           filename: filename2,
           statistics,
-          date_sent: expect.any(Date),
+          date: expect.any(Date),
         }];
 
       await store.daily.insertOneSuccess({ filename: filename1, statistics });
@@ -202,11 +202,11 @@ describe('Store component tests', () => {
         {
           filename: filename1,
           statistics,
-          date_sent: expect.any(Date),
+          date: expect.any(Date),
         }, {
           filename: filename2,
           statistics,
-          date_sent: expect.any(Date),
+          date: expect.any(Date),
         }];
 
       await store.daily.insertOneFail({ filename: filename1, statistics });


### PR DESCRIPTION
### Main Changes

- Change `date_sent` property to `date` to be more generic

### Other Changes

- Fix tests

### Context

#12 

### Changelog

- 2f30080 refactor: change date_sent property to just date by @neodmy
