### PR TITLE
Add sftp docker

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -19,10 +19,10 @@ module.exports = {
     channel: process.env.SLACK_CHANNEL,
   },
   sftp: {
-    hostname: process.env.SFTP_HOSTNAME,
-    port: process.env.SFTP_PORT,
-    username: process.env.SFTP_USERNAME,
-    password: process.env.SFTP_PASSWORD,
+    hostname: process.env.SFTP_HOSTNAME || 'localhost',
+    port: process.env.SFTP_PORT || 2222,
+    username: process.env.SFTP_USERNAME || 'username',
+    password: process.env.SFTP_PASSWORD || 'password',
   },
   controller: {
     clientId: process.env.CLIENT_ID,

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -1,6 +1,12 @@
 version: "3.5"
 
 services:
+  sftp:
+    build: ./sftp
+    container_name: sftp-echoes-backup-client
+    ports:
+        - "2222:22"
+    command: username:password:::/echoes
   mongo:
     image: mongo:3.6
     container_name: mongo-echoes-backup-client

--- a/docker/test/sftp/Dockerfile
+++ b/docker/test/sftp/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:jessie
+LABEL Adrian Dvergsdal [atmoz.net]
+
+# - Install packages
+# - OpenSSH needs /var/run/sshd to run
+# - Remove generic host keys, entrypoint generates unique keys
+RUN apt-get update && \
+    apt-get -y install openssh-server && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /var/run/sshd && \
+    rm -f /etc/ssh/ssh_host_*key*
+
+COPY sftp-users.conf /etc/sftp-users.conf
+COPY sshd_config /etc/ssh/sshd_config
+COPY entrypoint /
+COPY README.md /
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint"]

--- a/docker/test/sftp/README.md
+++ b/docker/test/sftp/README.md
@@ -1,0 +1,142 @@
+# Supported tags and respective `Dockerfile` links
+
+- [`debian-jessie`, `debian`, `latest` (*Dockerfile*)](https://github.com/atmoz/sftp/blob/master/Dockerfile) [![](https://images.microbadger.com/badges/image/atmoz/sftp.svg)](http://microbadger.com/images/atmoz/sftp "Get your own image badge on microbadger.com")
+- [`alpine-3.4`, `alpine` (*Dockerfile*)](https://github.com/atmoz/sftp/blob/alpine/Dockerfile) [![](https://images.microbadger.com/badges/image/atmoz/sftp:alpine.svg)](http://microbadger.com/images/atmoz/sftp "Get your own image badge on microbadger.com")
+
+# Securely share your files
+
+Easy to use SFTP ([SSH File Transfer Protocol](https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol)) server with [OpenSSH](https://en.wikipedia.org/wiki/OpenSSH).
+This is an automated build linked with the [debian](https://hub.docker.com/_/debian/) and [alpine](https://hub.docker.com/_/alpine/) repositories.
+
+# Usage
+
+- Define users as command arguments, STDIN or mounted in `/etc/sftp-users.conf`
+  (syntax: `user:pass[:e][:uid[:gid[:dir1[,dir2]...]]]...`).
+  - Set UID/GID manually for your users if you want them to make changes to
+    your mounted volumes with permissions matching your host filesystem.
+  - Add directory names at the end, if you want to create them and/or set user
+    ownership. Perfect when you just want a fast way to upload something without
+    mounting any directories, or you want to make sure a directory is owned by
+    a user (chown -R).
+- Mount volumes in user's home directory.
+  - The users are chrooted to their home directory, so you must mount the
+    volumes in separate directories inside the user's home directory
+    (/home/user/**mounted-directory**).
+
+# Examples
+
+
+## Simplest docker run example
+
+```
+docker run -p 22:22 -d atmoz/sftp foo:pass:::upload
+```
+
+User "foo" with password "pass" can login with sftp and upload files to a folder called "upload". No mounted directories or custom UID/GID. Later you can inspect the files and use `--volumes-from` to mount them somewhere else (or see next example).
+
+## Sharing a directory from your computer
+
+Let's mount a directory and set UID:
+
+```
+docker run \
+    -v /host/share:/home/foo/share \
+    -p 2222:22 -d atmoz/sftp \
+    foo:123:1001
+```
+
+### Using Docker Compose:
+
+```
+sftp:
+    image: atmoz/sftp
+    volumes:
+        - /host/share:/home/foo/share
+    ports:
+        - "2222:22"
+    command: foo:123:1001
+```
+
+### Logging in
+
+The OpenSSH server runs by default on port 22, and in this example, we are
+forwarding the container's port 22 to the host's port 2222. To log in with the
+OpenSSH client, run: `sftp -P 2222 foo@<host-ip>`
+
+## Store users in config
+
+```
+docker run \
+    -v /host/users.conf:/etc/sftp-users.conf:ro \
+    -v /host/share:/home/foo/share \
+    -v /host/documents:/home/foo/documents \
+    -v /host/http:/home/bar/http \
+    -p 2222:22 -d atmoz/sftp
+```
+
+/host/users.conf:
+
+```
+foo:123:1001
+bar:abc:1002
+```
+
+## Encrypted password
+
+Add `:e` behind password to mark it as encrypted. Use single quotes if using terminal.
+
+```
+docker run \
+    -v /host/share:/home/foo/share \
+    -p 2222:22 -d atmoz/sftp \
+    'foo:$1$0G2g0GSt$ewU0t6GXG15.0hWoOX8X9.:e:1001'
+```
+
+Tip: you can use [atmoz/makepasswd](https://hub.docker.com/r/atmoz/makepasswd/) to generate encrypted passwords:  
+`echo -n "your-password" | docker run -i --rm atmoz/makepasswd --crypt-md5 --clearfrom=-`
+
+## Using SSH key (and no password)
+
+Mount all public keys in the user's `.ssh/keys/` directory. All keys are automatically
+appended to `.ssh/authorized_keys`.
+
+```
+docker run \
+    -v /host/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
+    -v /host/id_other.pub:/home/foo/.ssh/keys/id_other.pub:ro \
+    -v /host/share:/home/foo/share \
+    -p 2222:22 -d atmoz/sftp \
+    foo::1001
+```
+
+## Execute custom scripts or applications
+
+Put your programs in `/etc/sftp.d/` and it will automatically run when the container starts.
+See next section for an example.
+
+## Bindmount dirs from another location
+
+If you are using `--volumes-from` or just want to make a custom directory
+available in user's home directory, you can add a script to `/etc/sftp.d/` that
+bindmounts after container starts.
+
+```
+#!/bin/bash
+# File mounted as: /etc/sftp.d/bindmount.sh
+# Just an example (make your own)
+
+function bindmount() {
+    if [ -d "$1" ]; then
+        mkdir -p "$2"
+    fi
+    mount --bind $3 "$1" "$2"
+}
+
+# Remember permissions, you may have to fix them:
+# chown -R :users /data/common
+
+bindmount /data/admin-tools /home/admin/tools
+bindmount /data/common /home/dave/common
+bindmount /data/common /home/peter/common
+bindmount /data/docs /home/peter/docs --read-only
+```

--- a/docker/test/sftp/entrypoint
+++ b/docker/test/sftp/entrypoint
@@ -1,0 +1,155 @@
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+userConfPath="/etc/sftp-users.conf"
+userConfFinalPath="/var/run/sftp-users.conf"
+
+function printHelp() {
+    echo "Add users as command arguments, STDIN or mounted in $userConfPath"
+    echo "Syntax: user:pass[:e][:uid[:gid[:dir1[,dir2]...]]] ..."
+    echo "Use --readme for more information and examples."
+}
+
+function printReadme() {
+    cat /README.md
+    echo "TIP: Read this in HTML format here: https://github.com/atmoz/sftp"
+}
+
+function createUser() {
+    IFS=':' read -a param <<< $@
+    user="${param[0]}"
+    pass="${param[1]}"
+
+    if [ "${param[2]}" == "e" ]; then
+        chpasswdOptions="-e"
+        uid="${param[3]}"
+        gid="${param[4]}"
+        dir="${param[5]}"
+    else
+        uid="${param[2]}"
+        gid="${param[3]}"
+        dir="${param[4]}"
+    fi
+
+    if [ -z "$user" ]; then
+        echo "FATAL: You must at least provide a username."
+        exit 1
+    fi
+
+    if $(cat /etc/passwd | cut -d: -f1 | grep -q "^$user:"); then
+        echo "WARNING: User \"$user\" already exists. Skipping."
+        return 0
+    fi
+
+    useraddOptions="--no-user-group"
+
+    if [ -n "$uid" ]; then
+        useraddOptions="$useraddOptions --non-unique --uid $uid"
+    fi
+
+    if [ -n "$gid" ]; then
+        if ! $(cat /etc/group | cut -d: -f3 | grep -q "$gid"); then
+            groupadd --gid $gid "group_$gid"
+        fi
+
+        useraddOptions="$useraddOptions --gid $gid"
+    fi
+
+    useradd $useraddOptions $user
+    mkdir -p /home/$user
+    chown root:root /home/$user
+    chmod 755 /home/$user
+
+    if [ -n "$pass" ]; then
+        echo "$user:$pass" | chpasswd $chpasswdOptions
+    else
+        usermod -p "*" $user # disabled password
+    fi
+
+    # Add SSH keys to authorized_keys with valid permissions
+    if [ -d /home/$user/.ssh/keys ]; then
+        cat /home/$user/.ssh/keys/* >> /home/$user/.ssh/authorized_keys
+        chown $user /home/$user/.ssh/authorized_keys
+        chmod 600 /home/$user/.ssh/authorized_keys
+    fi
+
+    # Make sure dirs exists and has correct permissions
+    if [ -n "$dir" ]; then
+        IFS=',' read -a dirParam <<< $dir
+        for dirPath in ${dirParam[@]}; do
+            dirPath=/home/$user/$dirPath
+            echo "Creating and/or setting permissions on $dirPath"
+            mkdir -p $dirPath
+            chown -R $user:users $dirPath
+        done
+    fi
+}
+
+if [[ $1 =~ ^--help$|^-h$ ]]; then
+    printHelp
+    exit 0
+fi
+
+if [ "$1" == "--readme" ]; then
+    printReadme
+    exit 0
+fi
+
+# Create users only on first run
+if [ ! -f "$userConfFinalPath" ]; then
+
+    # Append mounted config to final config
+    if [ -f "$userConfPath" ]; then
+        cat "$userConfPath" | grep -v -e '^$' > "$userConfFinalPath"
+    fi
+
+    # Append users from arguments to final config
+    if [ ! -z "$USER" ]; then
+      for user in "$USER"; do
+          echo "$user" >> "$userConfFinalPath"
+      done
+    fi
+
+    # Append users from STDIN to final config
+    if [ ! -t 0 ]; then
+        while IFS= read -r user || [[ -n "$user" ]]; do
+            echo "$user" >> "$userConfFinalPath"
+        done
+    fi
+
+    # Check that we have users in config
+    if [ "$(cat "$userConfFinalPath" | wc -l)" == 0 ]; then
+        echo "FATAL: No users provided!"
+        printHelp
+        exit 3
+    fi
+
+    # Import users from final conf file
+    while IFS= read -r user || [[ -n "$user" ]]; do
+        createUser "$user"
+    done < "$userConfFinalPath"
+
+    # Generate unique ssh keys for this container, if needed
+    if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+        ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N '' < /dev/null
+    fi
+    if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+        ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N '' < /dev/null
+    fi
+fi
+
+# Source custom scripts, if any
+if [ -d /etc/sftp.d ]; then
+    for f in /etc/sftp.d/*; do
+        if [ -x "$f" ]; then
+            echo "Running $f ..."
+            $f
+        fi
+    done
+    unset f
+fi
+
+echo "Running server"
+
+exec /usr/sbin/sshd -D -e

--- a/docker/test/sftp/sftp-users.conf
+++ b/docker/test/sftp/sftp-users.conf
@@ -1,0 +1,1 @@
+username:password:::/echoes

--- a/docker/test/sftp/sshd_config
+++ b/docker/test/sftp/sshd_config
@@ -1,0 +1,22 @@
+# Secure defaults
+# See: https://stribika.github.io/2015/01/04/secure-secure-shell.html
+Protocol 2
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+
+# Faster connection
+# See: https://github.com/atmoz/sftp/issues/11
+UseDNS no
+
+# Limited access
+PermitRootLogin no
+X11Forwarding no
+AllowTcpForwarding yes
+
+# Force sftp and chroot jail
+Subsystem sftp internal-sftp
+ForceCommand internal-sftp
+ChrootDirectory %h
+
+# Enable this for more logs
+#LogLevel VERBOSE

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ const { defaults } = require('jest-config');
 require('./test/env');
 
 module.exports = {
+  testTimeout: 30000,
   testEnvironment: 'node',
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'js'],
   testPathIgnorePatterns: ['dist', 'config'],

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "node index.js",
     "test:report": "cross-env NODE_ENV=test jest --detectOpenHandles --forceExit --coverage",
     "test": "cross-env NODE_ENV=test jest --detectOpenHandles --forceExit --reporters=default",
-    "infra:up": "bash -c 'docker-compose --file docker/test/docker-compose.yml --project-name mongo-echoes-backup-client-test up -d --force-recreate --build'",
-    "infra:down": "bash -c 'docker-compose --file docker/test/docker-compose.yml --project-name mongo-echoes-backup-client-test stop'",
+    "infra:up": "bash -c 'docker-compose --file docker/test/docker-compose.yml --project-name echoes-backup-client-test up -d --force-recreate --build'",
+    "infra:down": "bash -c 'docker-compose --file docker/test/docker-compose.yml --project-name echoes-backup-client-test stop'",
     "lint": "eslint .",
     "manifest": "node_modules/make-manifest/bin/make-manifest",
     "gitLog": "node gitLogFormatter/index.js"

--- a/test/components/sftp/sftp.test.js
+++ b/test/components/sftp/sftp.test.js
@@ -4,8 +4,7 @@ const system = require('../../../system');
 
 const slackBotMock = require('../../mocks/slackBotMock');
 
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Sftp component tests', () => {
+describe('Sftp component tests', () => {
   const sys = system();
   let sftp;
 
@@ -22,10 +21,11 @@ describe.skip('Sftp component tests', () => {
 
   test('should fail when local path does not exists', async () => {
     const filename = 'not_a_file';
-
+    const localPath = path.join(__dirname, '../../fixtures/temp/echoes/');
+    const remotePath = '/echoes';
     let err;
     try {
-      await sftp.uploadFile(filename);
+      await sftp.uploadFile({ filename, localPath, remotePath });
     } catch (error) {
       err = error;
     } finally {
@@ -36,19 +36,29 @@ describe.skip('Sftp component tests', () => {
 
   test('should upload a file when the directory does not exist', async () => {
     const filename = '2020-09-10.txt';
-    const fixtureFilePath = path.join(__dirname, `../../fixtures/temp/echoes/${filename}`);
+    const localPath = path.join(__dirname, '../../fixtures/temp/echoes/');
+    const remotePath = '/echoes/temp';
+    const fixtureFilePath = path.join(localPath, filename);
+
     fs.createFileSync(fixtureFilePath);
-    const result = await sftp.uploadFile(filename);
+    const result = await sftp.uploadFile({ filename, localPath, remotePath });
     expect(result).toEqual(expect.stringContaining('was successfully uploaded'));
     fs.removeSync(fixtureFilePath);
+    await sftp.removeDir({ remotePath });
   });
 
   test('should upload a file when the directory exists', async () => {
     const filename = '2020-09-10.txt';
-    const fixtureFilePath = path.join(__dirname, `../../fixtures/temp/echoes/${filename}`);
+    const localPath = path.join(__dirname, '../../fixtures/temp/echoes/');
+    const remotePath = '/echoes/tmp';
+    const fixtureFilePath = path.join(localPath, filename);
+
     fs.createFileSync(fixtureFilePath);
-    const result = await sftp.uploadFile(filename);
+    let result = await sftp.uploadFile({ filename, localPath, remotePath });
+    await sftp.removeFile({ filename, remotePath });
+    result = await sftp.uploadFile({ filename, localPath, remotePath });
     expect(result).toEqual(expect.stringContaining('was successfully uploaded'));
     fs.removeSync(fixtureFilePath);
+    await sftp.removeDir({ remotePath });
   });
 });


### PR DESCRIPTION
### Main Changes

- Add docker container for sftp
- Add sftp functions to remove files
- Extract connect to sftp function 

### Other Changes

- Add sftp config files for docker
- Add default values for sftp in service config
- Increase Jest timeout to test sftp
- Remane project name when executing docker-compose up and down
- Remove skip from sftp tests 

### Context

`Close #23`

### Changelog

- 04f2114 chore: rename docker project name by @neodmy
- f2fe2d7 test: increase jest timeout for sftp tests by @neodmy
- 33247e7 feat: extract connect to function and add remove functions by @neodmy
- ddb71db chore: add default values for sftp config by @neodmy
- d00ef5a chore: add docker config for sftp server by @neodmy
