### PR TITLE
Feat/add prod docker compose

### DIFF
--- a/components/controller/controller.js
+++ b/components/controller/controller.js
@@ -13,8 +13,11 @@ module.exports = () => {
       const processFilePromises = filenames.map(async filename => {
         try {
           const filenameWithoutExtension = filename.replace('.zip', '');
-          if (!filename.includes('zip')) await compressor.handleCompression(filenameWithoutExtension);
-          await uploader.handleUpload(filenameWithoutExtension);
+          const isFileToProcess = /^(19|20)\d\d([- /.])(0[1-9]|1[012])\2(0[1-9]|[12][0-9]|3[01])$/.test(filenameWithoutExtension);
+          if (isFileToProcess) {
+            if (!filename.includes('zip')) await compressor.handleCompression(filenameWithoutExtension);
+            await uploader.handleUpload(filenameWithoutExtension);
+          }
         } catch (error) {
           logger.error(error.message);
         }

--- a/config/default.js
+++ b/config/default.js
@@ -4,29 +4,29 @@ module.exports = {
     port: 4000,
   },
   mongo: {
-    url: process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost:27018',
+    url: process.env.MONGO_CONNECTION_STRING,
     options: { useUnifiedTopology: true },
   },
   store: {
-    collection: process.env.FAIL_COLLECTION_NAME || 'fail',
-    database: process.env.DAILY_DATABASE_NAME || 'echoes-backup',
+    collection: 'fail',
+    database: 'echoes-backup',
   },
   slack: {
-    status: process.env.SLACK_STATUS || 'active',
+    status: process.env.SLACK_STATUS,
     token: process.env.SLACK_TOKEN,
     channel: process.env.SLACK_CHANNEL,
   },
   sftp: {
-    hostname: process.env.SFTP_HOSTNAME || 'localhost',
-    port: process.env.SFTP_PORT || 2222,
-    username: process.env.SFTP_USERNAME || 'username',
-    password: process.env.SFTP_PASSWORD || 'password',
+    hostname: process.env.SFTP_HOSTNAME,
+    port: process.env.SFTP_PORT,
+    username: process.env.SFTP_USERNAME,
+    password: process.env.SFTP_PASSWORD,
   },
   controller: {
     clientId: process.env.CLIENT_ID,
-    remotePath: process.env.REMOTE_DIRECTORY || 'echoes/temp',
-    localPath: process.env.ECHOES_SOURCE_DIRECTORY,
-    removalOffset: process.env.REMOVAL_OFFSET || 21,
+    remotePath: process.env.REMOTE_DIRECTORY,
+    localPath: '/echoes',
+    removalOffset: process.env.REMOVAL_OFFSET || 1,
   },
   routes: {
     admin: {

--- a/config/test.js
+++ b/config/test.js
@@ -1,28 +1,30 @@
+const path = require('path');
+
 module.exports = {
   logger: { transport: null },
   mongo: {
-    url: process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost:27018',
+    url: 'mongodb://localhost:27018',
     options: { useUnifiedTopology: true },
   },
   store: {
-    collection: process.env.FAIL_COLLECTION_NAME || 'fail',
-    database: process.env.DAILY_DATABASE_NAME || 'echoes-backup',
+    collection: 'fail',
+    database: 'echoes-backup',
   },
   slack: {
-    status: process.env.SLACK_STATUS || 'active',
-    token: process.env.SLACK_TOKEN,
-    channel: process.env.SLACK_CHANNEL,
+    status: 'active',
+    token: 'token',
+    channel: 'channel',
   },
   sftp: {
-    hostname: process.env.SFTP_HOSTNAME || 'localhost',
-    port: process.env.SFTP_PORT || 2222,
-    username: process.env.SFTP_USERNAME || 'username',
-    password: process.env.SFTP_PASSWORD || 'password',
+    hostname: 'localhost',
+    port: 2222,
+    username: 'username',
+    password: 'password',
   },
   controller: {
-    clientId: process.env.CLIENT_ID,
-    remotePath: process.env.REMOTE_DIRECTORY || 'echoes/temp',
-    localPath: process.env.ECHOES_SOURCE_DIRECTORY,
-    removalOffset: process.env.REMOVAL_OFFSET || 21,
+    clientId: 'Fuenlabrada',
+    remotePath: 'echoes/temp',
+    localPath: path.join(__dirname, '..', 'test', 'fixtures', 'temp', 'echoes'),
+    removalOffset: 21,
   },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.5"
+
+services:
+  echoes-backup-client:
+    build:
+      context: ./Dockerfile
+    container_name:  echoes-backup-client
+    environment:
+      # SLACK
+      SLACK_STATUS: inactive
+      SLACK_TOKEN: token
+      SLACK_CHANNEL: channel
+      # SFTP
+      SFTP_HOSTNAME: hostname
+      SFTP_PORT: 22
+      SFTP_USERNAME: username
+      SFTP_PASSWORD: password
+      # DIRECTORIES
+      REMOTE_DIRECTORY: /mnt/kepler/meteoros/detecciones
+      # CLIENT
+      CLIENT_ID: client
+      REMOVAL_OFFSET: 21
+      # DATABASE
+      MONGO_CONNECTION_STRING: mongodb://mongo-echoes-backup-client:27018
+    ports:
+      - "4000:4000"
+    volumes:
+      - /home/meteoros20/echoes:/echoes
+  mongo:
+    image: mongo:3.6
+    container_name: mongo-echoes-backup-client
+    volumes:
+      - /data/db
+    ports:
+      - "27018:27017"

--- a/test/components/controller/compressor.test.js
+++ b/test/components/controller/compressor.test.js
@@ -8,7 +8,7 @@ const storeMock = require('../../mocks/storeMock');
 
 const {
   controller: { localPath },
-} = require('../../../config/default');
+} = require('../../../config/test');
 
 describe('Compressor component tests', () => {
   const sys = system();

--- a/test/components/controller/uploader.test.js
+++ b/test/components/controller/uploader.test.js
@@ -10,7 +10,7 @@ const {
   controller: {
     localPath, remotePath, clientId, removalOffset,
   },
-} = require('../../../config/default');
+} = require('../../../config/test');
 
 describe('Uploader component tests', () => {
   const sys = system();
@@ -71,7 +71,7 @@ describe('Uploader component tests', () => {
       }
     });
 
-    test('should success when the upload to SFTP server success and not to remove the file', async () => {
+    test('should success when the upload to SFTP server success on the first try and not to remove the file', async () => {
       const filename = getFilename(false);
       const failStatus = 'failed_to_send';
 
@@ -97,7 +97,7 @@ describe('Uploader component tests', () => {
       }
     });
 
-    test('should success when the upload to SFTP server success and remove the file', async () => {
+    test('should success when the upload to SFTP server success on the first try and remove the file', async () => {
       const filename = getFilename(true);
       const failStatus = 'failed_to_send';
 


### PR DESCRIPTION
### Main Changes

- Add `docker-compose` for production with `mongoDb` and the app build (including env vars)

### Other Changes

- Amend env vars in the default and test config file
- Use test values in tests

### Context

Close #32 

### Changelog

- 2eb93c2 chore: add docker-compose for production by @neodmy
- bfab18c test: use test config values in tests by @neodmy
- 756274b feat: add regex to avoid processing invalid files by @neodmy
- 8a5dbba chore: set fixed config for tests and amend default config by @neodmy
