### PR TITLE
Refactor/delete old files

### DIFF
--- a/components/controller/uploader.js
+++ b/components/controller/uploader.js
@@ -3,25 +3,17 @@ const path = require('path');
 
 module.exports = () => {
   const start = async ({
-    config, logger, archiver, store, slack, sftp,
+    config, logger, store, slack, sftp,
   }) => {
     debug('Initializing controller');
     const {
-      localPath, remotePath, clientId, removalOffset,
+      localPath, remotePath, clientId,
     } = config;
 
     const getcurrentRetries = async ({ filename, status }) => {
       const currentFail = await store.getOne({ filename, status });
       if (!currentFail) return 0;
       return currentFail.retries;
-    };
-
-    const shouldRemove = filename => {
-      if (!removalOffset) return false;
-      const removalDate = new Date();
-      removalDate.setDate(removalDate.getDate() - removalOffset);
-      const fileDate = new Date(filename);
-      return removalDate > fileDate;
     };
 
     const handleUpload = async filename => {
@@ -33,8 +25,8 @@ module.exports = () => {
 
         await sftp.uploadFile({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
 
-        if (shouldRemove(filename)) await archiver.deleteFile(path.join(localPath, `${filename}.zip`));
         if (currentRetries) await store.deleteOne({ filename, status: failStatus });
+        await store.upsertOne({ filename, status: 'sent' });
       } catch (error) {
         const errorMessage = `Error uploading file. File will be saved for future resending | File ${filename}`;
         logger.error(errorMessage);

--- a/test/util/util.test.js
+++ b/test/util/util.test.js
@@ -1,0 +1,23 @@
+const { shouldRemove } = require('../../util');
+const { controller: { removalOffset } } = require('../../config/test');
+
+describe('shouldRemove', () => {
+  const getFilename = (shouldBeRemoved = false) => {
+    const today = new Date();
+    const offset = shouldBeRemoved ? removalOffset + 1 : 0;
+    today.setDate(today.getDate() - offset);
+    return today.toISOString().split('T')[0];
+  };
+
+  test('should return true if the file is older than date set by the offset', () => {
+    const oldFilename = getFilename(true);
+
+    expect(shouldRemove(oldFilename, removalOffset)).toBe(true);
+  });
+
+  test('should return false if the file is not older than date set by the offset', () => {
+    const oldFilename = getFilename(false);
+
+    expect(shouldRemove(oldFilename, removalOffset)).toBe(false);
+  });
+});

--- a/util/index.js
+++ b/util/index.js
@@ -1,0 +1,11 @@
+const shouldRemove = (filename, removalOffset) => {
+  if (!removalOffset) return false;
+  const removalDate = new Date();
+  removalDate.setDate(removalDate.getDate() - removalOffset);
+  const fileDate = new Date(filename);
+  return removalDate > fileDate;
+};
+
+module.exports = {
+  shouldRemove,
+};


### PR DESCRIPTION
### Main Changes

- Add `deleteOldFiles` function to delete files independently from upload

### Other Changes

- Upload functionality will now save the successful file sent to the server for the `deleteOldFiles` function to delete the files safely, only when they've been backed up.

### Context

Close #35 

### Changelog

- 09c5b27 feat: add deleteOldFiles function by @neodmy
- 3349c2a feat: move shouldRemove function to util by @neodmy
- cad6ebf refactor: remove call to deleteFile when uploading a file successfully by @neodmy
