### PR TITLE
fix: delete zip files

### DIFF
--- a/components/controller/controller.js
+++ b/components/controller/controller.js
@@ -66,7 +66,7 @@ module.exports = () => {
         try {
           if (shouldRemove(filename, removalOffset)) {
             logger.info(`Deleting file | Filename ${filename}`);
-            await archiver.deleteFile(path.join(localPath, filename));
+            await archiver.deleteFile(path.join(localPath, `${filename}.zip`));
             await store.deleteOne({ filename, status });
           }
           logger.info(`File is not older than offset. File will not be deleted | Filename ${filename}`);

--- a/test/components/controller/controller.test.js
+++ b/test/components/controller/controller.test.js
@@ -508,8 +508,8 @@ describe('Controller component tests', () => {
       } finally {
         expect(err).toBeUndefined();
 
-        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, fileToCompress1.filename));
-        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, fileToCompress2.filename));
+        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, `${fileToCompress1.filename}.zip`));
+        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, `${fileToCompress2.filename}.zip`));
 
         expect(store.deleteOne).toHaveBeenCalledWith({ filename: fileToCompress1.filename, status: fileToCompress1.status });
         expect(store.deleteOne).toHaveBeenCalledWith({ filename: fileToCompress2.filename, status: fileToCompress2.status });
@@ -541,7 +541,7 @@ describe('Controller component tests', () => {
       } finally {
         expect(err).toBeUndefined();
 
-        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, fileToCompress1.filename));
+        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, `${fileToCompress1.filename}.zip`));
 
         expect(store.deleteOne).toHaveBeenCalledWith({ filename: fileToCompress1.filename, status: fileToCompress1.status });
       }
@@ -573,8 +573,8 @@ describe('Controller component tests', () => {
       } finally {
         expect(err).toBeUndefined();
 
-        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, fileToCompress1.filename));
-        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, fileToCompress2.filename));
+        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, `${fileToCompress1.filename}.zip`));
+        expect(archiver.deleteFile).toHaveBeenCalledWith(path.join(localPath, `${fileToCompress2.filename}.zip`));
 
         expect(store.deleteOne).toHaveBeenCalledWith({ filename: fileToCompress2.filename, status: fileToCompress2.status });
       }


### PR DESCRIPTION
### Main Changes

Fix `deleteOldFiles` to remove only zip files.

### Other Changes

Fix tests

### Context

Close #38 

### Changelog

- 202f6b4 fix: delete zip files by @neodmy

