### PR TITLE
Refactor/upload dir

### DIFF
--- a/components/controller/uploader.js
+++ b/components/controller/uploader.js
@@ -24,7 +24,7 @@ module.exports = () => {
         logger.info(`File upload has started | Filename ${filename}`);
         currentRetries = await getcurrentRetries({ filename, status: failStatus });
 
-        await sftp.uploadFile({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
+        await sftp.uploadDir({ dirName: filename, localPath, remotePath: path.join(remotePath, clientId) });
 
         if (currentRetries) await store.deleteOne({ filename, status: failStatus });
         await store.upsertOne({ filename, status: 'sent' });

--- a/components/sftp/sftp.js
+++ b/components/sftp/sftp.js
@@ -35,6 +35,21 @@ module.exports = () => {
       }
     };
 
+    const uploadDir = async ({ dirName, localPath, remotePath }) => {
+      await connect();
+
+      try {
+        const result = await client.uploadDir(path.join(localPath, dirName), path.join(remotePath, dirName));
+        logger.info(`Uploading directory ${dirName} to server | Result ${result}`);
+        return result;
+      } catch (error) {
+        logger.error(`Error uploading directory to SFTP server | Error ${error.stack}`);
+        throw error;
+      } finally {
+        await client.end();
+      }
+    };
+
     const removeDir = async ({ remotePath }) => {
       await connect();
 
@@ -112,7 +127,7 @@ module.exports = () => {
     };
 
     return {
-      uploadFile, removeDir, removeFile, createFile, appendToFile, checkFileExists,
+      uploadFile, uploadDir, removeDir, removeFile, createFile, appendToFile, checkFileExists,
     };
   };
 

--- a/test/components/controller/uploader.test.js
+++ b/test/components/controller/uploader.test.js
@@ -43,7 +43,7 @@ describe('Uploader component tests', () => {
       const sentStatus = 'sent';
 
       store.getOne.mockResolvedValueOnce(null);
-      sftp.uploadFile.mockRejectedValueOnce(new Error('Error uploading file to SFTP'));
+      sftp.uploadDir.mockRejectedValueOnce(new Error('Error uploading file to SFTP'));
 
       let err;
       try {
@@ -54,7 +54,7 @@ describe('Uploader component tests', () => {
         expect(err).toBeDefined();
 
         expect(store.getOne).toHaveBeenCalledWith({ filename, status: failStatus });
-        expect(sftp.uploadFile).toHaveBeenCalledWith({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
+        expect(sftp.uploadDir).toHaveBeenCalledWith({ dirName: filename, localPath, remotePath: path.join(remotePath, clientId) });
 
         expect(store.deleteOne).not.toHaveBeenCalled();
         expect(store.upsertOne).not.toHaveBeenCalledWith({ filename, status: sentStatus });
@@ -70,7 +70,7 @@ describe('Uploader component tests', () => {
       const sentStatus = 'sent';
 
       store.getOne.mockResolvedValueOnce(null);
-      sftp.uploadFile.mockResolvedValueOnce();
+      sftp.uploadDir.mockResolvedValueOnce();
 
       let err;
       try {
@@ -81,7 +81,7 @@ describe('Uploader component tests', () => {
         expect(err).toBeUndefined();
 
         expect(store.getOne).toHaveBeenCalledWith({ filename, status: failStatus });
-        expect(sftp.uploadFile).toHaveBeenCalledWith({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
+        expect(sftp.uploadDir).toHaveBeenCalledWith({ dirName: filename, localPath, remotePath: path.join(remotePath, clientId) });
 
         expect(store.deleteOne).not.toHaveBeenCalled();
         expect(store.upsertOne).toHaveBeenCalledWith({ filename, status: sentStatus });
@@ -99,7 +99,7 @@ describe('Uploader component tests', () => {
       store.getOne.mockResolvedValueOnce({
         filename, status: failStatus, retries: 1,
       });
-      sftp.uploadFile.mockRejectedValueOnce(new Error('Error uploading file to SFTP'));
+      sftp.uploadDir.mockRejectedValueOnce(new Error('Error uploading file to SFTP'));
 
       let err;
       try {
@@ -110,7 +110,7 @@ describe('Uploader component tests', () => {
         expect(err).toBeDefined();
 
         expect(store.getOne).toHaveBeenCalledWith({ filename, status: failStatus });
-        expect(sftp.uploadFile).toHaveBeenCalledWith({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
+        expect(sftp.uploadDir).toHaveBeenCalledWith({ dirName: filename, localPath, remotePath: path.join(remotePath, clientId) });
 
         expect(store.deleteOne).not.toHaveBeenCalled();
         expect(store.upsertOne).not.toHaveBeenCalledWith({ filename, status: sentStatus });
@@ -128,7 +128,7 @@ describe('Uploader component tests', () => {
       store.getOne.mockResolvedValueOnce({
         filename, status: failStatus, retries: 1,
       });
-      sftp.uploadFile.mockResolvedValueOnce();
+      sftp.uploadDir.mockResolvedValueOnce();
 
       let err;
       try {
@@ -139,7 +139,7 @@ describe('Uploader component tests', () => {
         expect(err).toBeUndefined();
 
         expect(store.getOne).toHaveBeenCalledWith({ filename, status: failStatus });
-        expect(sftp.uploadFile).toHaveBeenCalledWith({ filename: `${filename}.zip`, localPath, remotePath: path.join(remotePath, clientId) });
+        expect(sftp.uploadDir).toHaveBeenCalledWith({ dirName: filename, localPath, remotePath: path.join(remotePath, clientId) });
 
         expect(store.deleteOne).toHaveBeenCalledWith({ filename, status: failStatus });
         expect(store.upsertOne).toHaveBeenCalledWith({ filename, status: sentStatus });

--- a/test/components/sftp/sftp.test.js
+++ b/test/components/sftp/sftp.test.js
@@ -73,6 +73,40 @@ describe('Sftp component tests', () => {
     }
   });
 
+  test('should fail when the local directory does not exists', async () => {
+    const dirName = 'not_a_directory';
+    const localPath = path.join(__dirname, '../../fixtures/temp/echoes/');
+    const remotePath = '/echoes';
+    let err;
+    try {
+      await sftp.uploadDir({ dirName, localPath, remotePath });
+    } catch (error) {
+      err = error;
+    } finally {
+      expect(err).toBeDefined();
+      expect(err.message).toEqual(expect.stringContaining('No such directory'));
+    }
+  });
+
+  test('should upload a directory when the directory does not exists in the FTP server', async () => {
+    const dirName = '2020-09-10';
+    const localPath = path.join(__dirname, '../../fixtures/original/echoes/');
+    const remotePath = '/echoes/tmp';
+
+    let result;
+    let err;
+    try {
+      result = await sftp.uploadDir({ dirName, localPath, remotePath });
+    } catch (error) {
+      err = error;
+    } finally {
+      expect(err).toBeUndefined();
+      expect(result).toEqual(expect.stringContaining('uploaded to /echoes/tmp/2020-09-10'));
+
+      await sftp.removeDir({ remotePath });
+    }
+  });
+
   test('should create a file in the FTP server with no content', async () => {
     const filename = '2020-09-10.txt';
     const remotePath = '/echoes/tmp';

--- a/test/mocks/sftpMock.js
+++ b/test/mocks/sftpMock.js
@@ -6,6 +6,7 @@ module.exports = () => {
     createFile: jest.fn(),
     appendToFile: jest.fn(),
     checkFileExists: jest.fn(),
+    uploadDir: jest.fn(),
   });
 
   return { start };


### PR DESCRIPTION
### Main Changes

- Add `uploadDir` function to sftp component
- Use `uploadDir` in `uploader` component instead of `uploadFile`

### Other Changes

Amend tests and include `uploadDir` in sftp mock

### Context

Please add here issues/Prs context and actions if needed as a list

Notes:

Close #46 

### Changelog

- 0af404f refactor: use uploadDir instead of uploadFile by @neodmy
- b5a8c33 feat: add uploadDir by @neodmy
