### PR TITLE
feat: add toggles for initial CSV and Upload processes

### DIFF
--- a/components/controller/controller.js
+++ b/components/controller/controller.js
@@ -8,7 +8,9 @@ module.exports = () => {
     config, logger, archiver, uploader, csv, store,
   }) => {
     debug('Initializing controller');
-    const { localPath, removalOffset } = config;
+    const {
+      localPath, removalOffset, initCsv, initUpload,
+    } = config;
 
     const init = async () => {
       try {
@@ -20,8 +22,19 @@ module.exports = () => {
             const isFileToProcess = /^(19|20)\d\d([- /.])(0[1-9]|1[012])\2(0[1-9]|[12][0-9]|3[01])$/.test(filename);
             if (isFileToProcess) {
               logger.info(`Synchronizing file | Filename ${filename}`);
-              await csv.handleCsvData(filename);
-              await uploader.handleUpload(filename);
+
+              if (initCsv === 'active') {
+                await csv.handleCsvData(filename);
+              } else {
+                logger.warn(`Initial CSV process is not active by configuration | Skipping CSV process for file ${filename}`);
+              }
+
+              if (initUpload === 'active') {
+                await uploader.handleUpload(filename);
+              } else {
+                logger.warn(`Initial upload is not active by configuration | Skipping CSV process for file ${filename}`);
+              }
+
               logger.info(`File synchornization has been completed | Filename ${filename}`);
             }
           } catch (error) {

--- a/config/default.js
+++ b/config/default.js
@@ -8,7 +8,7 @@ module.exports = {
     options: { useUnifiedTopology: true },
   },
   store: {
-    collection: 'fail',
+    collection: 'results',
     database: 'echoes-backup',
   },
   slack: {
@@ -25,7 +25,9 @@ module.exports = {
     clientId: process.env.CLIENT_ID,
     remotePath: process.env.REMOTE_DIRECTORY,
     localPath: '/echoes',
-    removalOffset: process.env.REMOVAL_OFFSET || 1,
+    removalOffset: process.env.REMOVAL_OFFSET,
+    initCsv: process.env.INITIAL_CSV || 'inactive',
+    initUpload: process.env.INITIAL_UPLOAD || 'inactive',
   },
   routes: {
     admin: {

--- a/config/test.js
+++ b/config/test.js
@@ -26,5 +26,7 @@ module.exports = {
     remotePath: 'echoes/temp',
     localPath: path.join(__dirname, '..', 'test', 'fixtures', 'temp', 'echoes'),
     removalOffset: 21,
+    initCsv: process.env.INITIAL_CSV || 'active',
+    initUpload: process.env.INITIAL_UPLOAD || 'active',
   },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,21 +8,29 @@ services:
     container_name:  echoes-backup-client
     environment:
       # SLACK
-      SLACK_STATUS: inactive
       SLACK_TOKEN: token
       SLACK_CHANNEL: channel
+
       # SFTP
       SFTP_HOSTNAME: hostname
       SFTP_PORT: 22
       SFTP_USERNAME: username
       SFTP_PASSWORD: password
+
       # DIRECTORIES
       REMOTE_DIRECTORY: /mnt/kepler/meteoros/detecciones
+
       # CLIENT
       CLIENT_ID: client
-      REMOVAL_OFFSET: 21
+      REMOVAL_OFFSET: 0
+
+      # INIT
+      INITIAL_CSV: inactive
+      INITIAL_UPLOAD: inactive
+
       # DATABASE
       MONGO_CONNECTION_STRING: mongodb://mongo-echoes-backup-client:27017
+      
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
### Main Changes

Add toggles to enable or disable initial CSV and Upload processes.

### Other Changes

- Remove `SLACK_STATUS` env var from `docker-compose` as it was not used.
- Add env vars to config and `docker-compose`

### Context

No ticket related

### Changelog

- 23ba130 feat: add toggles for initial CSV and Upload processes by @neodmy
